### PR TITLE
Config boundaries for word only matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,5 @@ pip-log.txt
 .mr.developer.cfg
 
 node_modules
+
+bower_components

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ $('#content').highlight('lorem', {
   wordsOnly: true
 });
 
+// search only for the entire word 'C#'
+// and make sure that the word boundary can also
+// be a 'non-word' character, as well as a regex latin1 only boundary:
+$('#content').highlight('C#', {
+  wordsOnly: true,
+  wordsBoundary: '[\\b\\W]'
+});
+
+
 // don't ignore case during search of term 'lorem'
 $('#content').highlight('lorem', {
   caseSensitive: true

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>QUnit Example</title>
+    <script src="../bower_components/jquery/dist/jquery.js"></script>
+    <script src="../jquery.highlight.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.18.0.css">
+    <style>
+      .highlight{
+        background-color: yellow;
+      }
+      em.important{
+        background-color: red;  
+      }
+    </style>
+  </head>
+  <body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <script src="http://code.jquery.com/qunit/qunit-1.18.0.js"></script>
+    <script src="tests.js"></script>
+
+    <div id="test1">
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no C# tales killick trysail mizzenmast Jolly Roger holystone crimp.
+    </div>
+
+    <div id="test2">
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no tales killick trysail mizzenmast Jolly Roger holystone crimp.
+    </div>
+
+    <div id="test3">
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no tales killick trysail mizzenmast Jolly Roger holystone crimp.
+    </div>
+    <div id="test4">
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no tales killick trysail mizzenmast Jolly Roger holystone crimp.
+    </div>
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>QUnit Example</title>
+    <title>JQuery Highlight</title>
     <script src="../bower_components/jquery/dist/jquery.js"></script>
     <script src="../jquery.highlight.js"></script>
     <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.18.0.css">
@@ -26,14 +26,20 @@
     </div>
 
     <div id="test2">
-      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no tales killick trysail mizzenmast Jolly Roger holystone crimp.
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no C# tales killick trysail mizzenmast Jolly Roger holystone crimp.
     </div>
 
     <div id="test3">
-      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no tales killick trysail mizzenmast Jolly Roger holystone crimp.
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no C# tales killick trysail mizzenmast Jolly Roger holystone crimp.
     </div>
     <div id="test4">
-      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no tales killick trysail mizzenmast Jolly Roger holystone crimp.
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no C# tales killick trysail mizzenmast Jolly Roger holystone crimp.
+    </div>
+    <div id="test5">
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no C# tales killick trysail mizzenmast Jolly Roger holystone crimp.
+    </div>
+    <div id="test6">
+      Aft tack cable swing the lead league main sheet scurvy warp brigantine lanyard. Crimp bucko gangplank sutler port reef sails rum Letter of Marque crack Jennys tea cup splice the main brace. Lookout Spanish Main reef dead men tell no C# tales killick trysail mizzenmast Jolly Roger holystone crimp.
     </div>
   </body>
 </html>

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,0 +1,30 @@
+QUnit.test("No options", function( assert ){
+    var $test = $('#test1');
+    $test.highlight('scurvy');
+    assert.ok( $( '.highlight' , $test ).length == 1 , "Ok got 1 highlighted piece of text");
+    $test.highlight( [ 'scurvy' , 'angplank' , 'lanyard' ] );
+    assert.ok( $( '.highlight' , $test ).length == 3 , "Ok got 3 highlighted pieces of text");
+});
+
+QUnit.test("Words only", function( assert ){
+    var $test = $('#test2');
+    $test.highlight('scurvy' , { wordsOnly: true});
+    assert.ok( $( '.highlight' , $test ).length == 1 , "Ok got 1 highlighted piece of text");
+    $test.highlight( [ 'scurvy' , 'angplank' , 'lanyard' , 'C#' ] , { wordsOnly: true } );
+    assert.ok( $( '.highlight' , $test ).length == 2 , "2 Highlights only");
+});
+
+QUnit.test("Case sensitive", function( assert ){
+    var $test = $('#test3');
+    $test.highlight('Scurvy' , { caseSensitive: true });
+    assert.ok( $( '.highlight' , $test ).length == 0 , "No Scurvy");
+    $test.highlight('Letter' , { caseSensitive: true });
+    assert.ok( $( '.highlight' , $test ).length == 1 , "Found 'Letter' in a case sensitive fashion");
+});
+
+QUnit.test("Custom element/class", function( assert ){
+    var $test = $('#test4');
+    $test.highlight('scurvy' , { element: 'em' , className: 'important'  } );
+    assert.ok( $( '.highlight' , $test ).length == 0 , "Ok got 0 higlighted pieces of text with default class");
+    assert.ok( $( 'em.important' , $test ).length == 1 , "Ok got 1 higlighted pieces of text with custom class");
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -28,3 +28,21 @@ QUnit.test("Custom element/class", function( assert ){
     assert.ok( $( '.highlight' , $test ).length == 0 , "Ok got 0 higlighted pieces of text with default class");
     assert.ok( $( 'em.important' , $test ).length == 1 , "Ok got 1 higlighted pieces of text with custom class");
 });
+
+QUnit.test("Word only with custom boundary - One match", function( assert ){
+    var $test = $('#test5');
+    $test.highlight('C#' , { wordsOnly: true , wordsBoundary: '\\W' });
+    assert.equal( $( '.highlight' , $test ).length, 1 , "Ok got 1 highlighted piece of text");
+    assert.equal( $( $( '.highlight' , $test )[0] ).text() , 'C#' , "Third highlight is C#");
+}); 
+
+QUnit.test("WordS only with custom boundary - Multi match" , function( assert ){
+    var $test = $('#test6');
+    $test.highlight('scurvy' , { wordsOnly: true  });
+    assert.ok( $( '.highlight' , $test ).length == 1 , "Ok got 1 highlighted piece of text");
+    $test.highlight( [ 'scurvy' , 'angplank' , 'lanyard' , 'C#' ] , { wordsOnly: true, wordsBoundary: '[\\b\\W]' } );
+    assert.equal( $( '.highlight' , $test ).length , 3 , "3 Highlights");
+    assert.equal( $( $( '.highlight' , $test )[0] ).text() , 'scurvy' , "First highlight is scurvy");
+    assert.equal( $( $( '.highlight' , $test )[1] ).text() , 'lanyard' , "Second highlight is lanyard");
+    assert.equal( $( $( '.highlight' , $test )[2] ).text() , 'C#' , "Third highlight is C#");
+});


### PR DESCRIPTION
This adds the ability to specify words boundary when in words only mode. Allows "advanced" usage, such as matching 'C#' in a text.

Additionally, this introduces Qunit tests to improve stability.